### PR TITLE
feat: Sort team search by program ID

### DIFF
--- a/src/commands/team.rs
+++ b/src/commands/team.rs
@@ -595,9 +595,9 @@ impl TeamCommand {
         }
 
         if let Ok(mut teams) = robotevents.teams(query).await {
-            // Sort by lowest program ID to prioritize VRC teams in the search
-            // NOTE: VRC Internally has an ID of 1, making it the lowest numeric program ID
-            teams.data.sort_by(|a, b| a.program.id.cmp(&b.program.id));
+            // Prioritize teams that are registered over teams that are not registered.
+            // From there, pick the team with the lowest numeric program ID (VRC has the lowest ID being `1`).
+            teams.data.sort_by_key(|team| (!team.registered, team.program.id));
 
             if let Some(team) = teams.data.iter().next() {
                 self.team = Some(team.clone()); // Cache value for later use. 

--- a/src/commands/team.rs
+++ b/src/commands/team.rs
@@ -596,7 +596,7 @@ impl TeamCommand {
 
         if let Ok(mut teams) = robotevents.teams(query).await {
             // Sort by lowest program ID to prioritize VRC teams in the search
-            // NOTE: VRC Internally has an ID of 1, making it the lowest numerical program ID
+            // NOTE: VRC Internally has an ID of 1, making it the lowest numeric program ID
             teams.data.sort_by(|a, b| a.program.id.cmp(&b.program.id));
 
             if let Some(team) = teams.data.iter().next() {

--- a/src/commands/team.rs
+++ b/src/commands/team.rs
@@ -594,7 +594,11 @@ impl TeamCommand {
             query = query.program(program_id_filter);
         }
 
-        if let Ok(teams) = robotevents.teams(query).await {
+        if let Ok(mut teams) = robotevents.teams(query).await {
+            // Sort by lowest program ID to prioritize VRC teams in the search
+            // NOTE: VRC Internally has an ID of 1, making it the lowest numerical program ID
+            teams.data.sort_by(|a, b| a.program.id.cmp(&b.program.id));
+
             if let Some(team) = teams.data.iter().next() {
                 self.team = Some(team.clone()); // Cache value for later use. 
                 return Ok(team.clone());


### PR DESCRIPTION
This has the effect of prioritizing VRC teams over other searches due to the VRC program having a low program ID (1). The order of team results will then go to VEXU (4), WORKSHOP (37), VIQRC (41), etc...

Active teams will additionally be prioritized before inactive ones regardless of program.