### PR TITLE
fix: some embed error handling, cleanup duplicate code

### DIFF
--- a/src/commands/team.rs
+++ b/src/commands/team.rs
@@ -489,11 +489,15 @@ impl TeamCommand {
                 for event in events.data {
                     embed = embed.field(
                         event.name,
-                        format!(
-                            "[View More](https://robotevents.com/robot-competitions/{}/{})",
-                            event.program.code.unwrap_or("UNKNOWN".to_string()),
+                        if let Some(code) = event.program.code {
+                            format!(
+                                "[View More](https://robotevents.com/robot-competitions/{}/{})",
+                                code,
+                                event.sku
+                            )
+                        } else {
                             event.sku
-                        ),
+                        },
                         true
                     );
                 }


### PR DESCRIPTION
- Previously we didn't cache data analysis in our `TeamCommand` struct properly, which caused it to refetch every time the user changed back to the analysis page.
- ditto for skills data, although this was already cached by `SkillsCache` so it was less of a big deal.
- There was a lot of duplicate code present related to unwrapping a team's program code, so I moved that into a variable at the top of the embed function
- If an event's program code isn't known, we don't know which program it belongs to and can't generate the "View More" link for users to click. Previous we'd just default to "VRC" if the program was unknown, but i've changed it to just display the event's SKU rather than linking if the program code is `None`.