### PR TITLE
feat: conditionally apply robot name field

### DIFF
--- a/src/commands/team.rs
+++ b/src/commands/team.rs
@@ -259,22 +259,19 @@ impl TeamCommand {
                             team.location.city, team.location.region.unwrap_or("Unknown".to_string()), team.location.country
                         ),
                         false,
-                    )
-                    // TODO: Should we hide this field entirely if no robot name is available?
-                    .field(
-                        "Robot Name",
-                        if let Some(robot_name) = &team.robot_name {
-                            robot_name
-                        } else {
-                            "Unnamed"
-                        },
-                        false,
-                    )
-                    .field(
-                        "Registered",
-                        if team.registered { "Yes" } else { "No" },
-                        false,
                     );
+                
+                if let Some(robot_name) = &team.robot_name {
+                    if !robot_name.is_empty() {
+                        embed = embed.field("Robot Name", robot_name, false);
+                    }
+                }
+
+                embed = embed.field(
+                    "Registered",
+                    if team.registered { "Yes" } else { "No" },
+                    false,
+                );
             },
             EmbedPage::Stats => {
                 let skills_ranking = if let Some(skills_ranking) = &self.skills_ranking {


### PR DESCRIPTION
Previously we would just show a field with no content (or "unnamed" if the name was null). In some cases RE will return `""` for some reason instead of `null`, so that's handled now too. It'll now just not add the field if the string is empty or `None`.

Previous behavior:
![image](https://github.com/LemLib/robostats/assets/42101043/43cd1e91-3d42-4375-bbff-49d82a2515b3)
