### PR TITLE
fix: map program codes for robotevent links

### DIFF
--- a/src/commands/team.rs
+++ b/src/commands/team.rs
@@ -491,8 +491,18 @@ impl TeamCommand {
                         event.name,
                         if let Some(code) = event.program.code {
                             format!(
-                                "[View More](https://robotevents.com/robot-competitions/{}/{})",
-                                code,
+                                "[View More](https://robotevents.com/robot-competitions/{}/{}.html)",
+                                match code.as_str() {
+                                    "VRC" => "vex-robotics-competition",
+                                    "VEXU" => "college-competition",
+                                    "VIQRC" => "vex-iq-competition",
+                                    "VAIRC" => "vex-ai-competition",
+                                    "BellAVR" => "bell-advanced-vertical-robotics-competition",
+                                    "TVRC" => "tsavrc",
+                                    "TVIQTC" => "tsaviqc",
+                                    "FAC" => "vex-factory-automation-competition",
+                                    _ => code.as_str(),
+                                },
                                 event.sku
                             )
                         } else {


### PR DESCRIPTION
Currently the links shown by the events tab are broken as they do not follow the correct format:
![image](https://github.com/LemLib/robostats/assets/14848722/8dcc5e56-56f8-4582-ace9-cd230c4d111a)

This PR maps the program code to the long names used by robotevents as well as adds a `.html` extension to the end of the link